### PR TITLE
ENH: Fix excessive memory usage for load_last

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "son"
-version = "0.4.1"
+version = "0.4.2"
 description = "Tools to read and write .son files"
 authors = ["Florian Knoop", "Marcel F. Langer"]
 license = "ISC"

--- a/son/last.py
+++ b/son/last.py
@@ -6,8 +6,10 @@ Read only the *last* entry of a son file.
 
 from .stream import token_metadata, token_record, delimiter, rebuild
 
+BATCH_SIZE = 64 * 1024  # stream is processed in chunks BATCH_SIZE bytes
 
-def last(stream):
+
+def last(stream, batch_size=BATCH_SIZE):
     # this will ONLY work with io.TextIOWrapper-derived streams,
     # such as the one obtained with open(file, encoding="utf-8"),
     # but NOT with StringIO (since it has a slightly different API)
@@ -15,7 +17,7 @@ def last(stream):
 
     record = []
     started = False
-    for line in reverse(stream):
+    for line in reverse(stream, batch_size=batch_size):
         if started:
             if line == delimiter(token_metadata) or line == delimiter(token_record):
                 break


### PR DESCRIPTION
When getting the last entry of large files, large amounts of memory are currently used. The reason for this is that lz's reverse method [defaults to using the full size of the file as batch_size](https://github.com/lycantropos/lz/blob/4c1a0a1eba16b47d518e3a104b8d8e33b6fe6ac0/lz/reversal.py#L157) for reading.

This sets a sane default of 64KB, fixing the problem. (I did some rough benchmarking, and 64KB seems to be a good, if somewhat arbitrary, choice.)
